### PR TITLE
kern: console: Add I/O delay time

### DIFF
--- a/kern/console.c
+++ b/kern/console.c
@@ -19,6 +19,7 @@ delay(void)
 	inb(0x84);
 	inb(0x84);
 	inb(0x84);
+	inb(0x84);
 }
 
 /***** Serial I/O code *****/


### PR DESCRIPTION
Add I/O delay time by instruction inb.

Signed-off-by: Zhang Qiao <zq216991@foxmail.com>